### PR TITLE
fix(6_libc.asm): add missing epilogue

### DIFF
--- a/6_libc.asm
+++ b/6_libc.asm
@@ -126,7 +126,13 @@ main:
 	call printf
 	mov rax, 1 ; exit status
 .end:
+	pop r15
+	pop r14
+	pop r13
+	pop r12
+	pop rbx
 	mov rsp, rbp
+	pop rbp
 	ret
 
 ; Exercises


### PR DESCRIPTION
Add missing 'register pop' to fix `segmentation fault (core dumped)  ./6_libc`.